### PR TITLE
Port and host set via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ To start the server:
 
     npm start
 
-If you wish to serve the site from a different port:
+If you wish to serve the site from a different port or host:
 
-    PORT=8000 npm start
+    HOST=0.0.0.0 PORT=8000 npm start

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ gulp.task('syncmedia', function() {
 
 gulp.task('webserver', function() {
   connect.server({
-    root: WEB_ROOT
+    root: WEB_ROOT,
+    port: process.env.PORT || 8080
   })
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ gulp.task('syncmedia', function() {
 gulp.task('webserver', function() {
   connect.server({
     root: WEB_ROOT,
+    host: process.env.HOST || 'localhost',
     port: process.env.PORT || 8080
   })
 });


### PR DESCRIPTION
Currently the documentation suggests the site can be run on a port other than the default by setting the `PORT` environment variable. However this variable is never read in anywhere or used. This PR fixes this bug and allows host to be configured as well.
