### PR TITLE
use s3 bucket URLs for Polar Sea Videos (fixes #18)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,10 +5,10 @@ var download = require('gulp-download');
 const WEB_ROOT = './';
 
 gulp.task('syncmedia', function() {
-  download('http://mozvr.com/projects/polarsea/content/videos/PolarSeaTrailer-3.mp4')
+  download('http://mozvr.com.s3.amazonaws.com/videos/PolarSeaTrailer-3.mp4')
     .pipe(gulp.dest('./demos/polarsea/videos/'));
-  download('http://mozvr.com/projects/nepal/videos/nepal.mp4')
-    .pipe(gulp.dest('./demos/nepal/videos/'));
+  download('http://mozvr.com.s3.amazonaws.com/videos/PolarSeaTrailer-3.webm')
+    .pipe(gulp.dest('./demos/polarsea/videos/'));
 });
 
 gulp.task('webserver', function() {


### PR DESCRIPTION
also removed `nepal.mp4` because we already have [`nepal.webm`](https://github.com/MozVR/webvr-demos/blob/master/demos/nepal/videos/nepal.webm) checked into the repo (since it's smaller than the 100 MB limit). and the http://mozvr.com/projects/nepal/videos/nepal.mp4 URL doesn't even work anymore (the Nepal videos aren't in the http://mozvr.com.s3.amazonaws.com/ bucket anymore).

r? @caseyyee
