### PR TITLE
README: clone URL should be https instead of ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WebVR Demos.
 ### GitHub
 
     # Clone the git repository from GitHub
-    git clone git@github.com:MozVR/webvr-demos.git
+    git clone https://github.com/MozVR/webvr-demos.git
 
     # Open the working directory
     cd webvr-demos


### PR DESCRIPTION
Using git@github.com to clone requires uploading a SSH key to GitHub; https is simpler.
